### PR TITLE
feat: NoDelimiter option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,9 @@ pprof:
 mem_prof:
 	go tool pprof -http=:8080 mem.pprof
 
+benchmark:
+	go test . -o "bench_mem.test" -run ^# -bench . -benchmem -count=10 -timeout 60m -v
+
 cpu_prof:
 	go tool pprof -http=:8080 cpu.pprof
 

--- a/bread_test.go
+++ b/bread_test.go
@@ -4,16 +4,24 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"go.uber.org/goleak"
 	"io"
+	"os"
 	"strconv"
 	"testing"
+	"time"
 )
+
+func TestMain(m *testing.M) {
+	os.Exit(m.Run())
+}
 
 func TestBread_Eat(t *testing.T) {
 	cases := [...]struct {
 		ctx         context.Context
 		bread       Bread
 		reader      io.Reader
+		timeout     time.Duration
 		expectedErr error
 	}{
 		// Test case: nil context
@@ -34,24 +42,52 @@ func TestBread_Eat(t *testing.T) {
 			bread:       Bread{},
 			expectedErr: ErrNilReader,
 		},
-		// Test case: success!
+		// Canceled context
 		{
 			ctx: context.TODO(),
 			bread: Bread{
 				Workers:    16,
 				WorkerFunc: func(ctx context.Context, buffer *[]byte) {},
 				BufferSeed: 5,
-				BufferSize: 1 * MB,
+				BufferSize: MB,
 			},
-			reader: buffer(300 * MB),
+			reader:      buffer(KB),
+			timeout:     time.Nanosecond,
+			expectedErr: context.DeadlineExceeded,
+		},
+		// Success!
+		{
+			ctx: context.TODO(),
+			bread: Bread{
+				Workers:    16,
+				WorkerFunc: func(ctx context.Context, buffer *[]byte) {},
+				BufferSeed: 5,
+				BufferSize: MB,
+			},
+			reader: buffer(GB),
 		},
 	}
 
-	for i, v := range cases {
+	for i, testCase := range cases {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
-			err := v.bread.Eat(v.ctx, v.reader)
-			if !errors.Is(err, v.expectedErr) {
-				t.Fatalf("expected error %v, got %v", v.expectedErr, err)
+			defer goleak.VerifyNone(t)
+
+			ctx := testCase.ctx
+
+			if testCase.timeout != 0 {
+				var cancel context.CancelFunc
+
+				ctx, cancel = context.WithTimeout(testCase.ctx, testCase.timeout)
+				defer cancel()
+			}
+
+			err := testCase.bread.Eat(ctx, testCase.reader)
+			if !errors.Is(err, testCase.expectedErr) {
+				t.Fatalf("expected error %v, got %v", testCase.expectedErr, err)
+			}
+
+			if err != nil {
+				t.Log("got error:", err)
 			}
 		})
 	}
@@ -89,6 +125,7 @@ func BenchmarkBread_Eat(b *testing.B) {
 		},
 	}
 
+	b.ReportAllocs()
 	b.ResetTimer()
 
 	for i, c := range cases {

--- a/bread_test.go
+++ b/bread_test.go
@@ -55,6 +55,21 @@ func TestBread_Eat(t *testing.T) {
 			timeout:     time.Nanosecond,
 			expectedErr: context.DeadlineExceeded,
 		},
+		// Go routine leaks
+		{
+			ctx: context.TODO(),
+			bread: Bread{
+				Workers: 16,
+				WorkerFunc: func(ctx context.Context, buffer *[]byte) {
+					<-ctx.Done()
+				},
+				BufferSeed: 5,
+				BufferSize: MB,
+			},
+			reader:      buffer(KB),
+			timeout:     300 * time.Millisecond,
+			expectedErr: context.DeadlineExceeded,
+		},
 		// Success!
 		{
 			ctx: context.TODO(),

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/yael-castro/bread
 
 go 1.21.0
+
+require go.uber.org/goleak v1.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
+go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=


### PR DESCRIPTION
In this release, I introduced a new option for the Bread struct. It is now possible to read batches of bytes without needing a delimiter.

Fixes made:
- I have fixed the errors that were not returned due to context cancellation.
- I have fixed the posible go routine leaks caused by Eat function not waits to go routines.
- I have fixed potential go routine leaks in the Eat function (It did not wait for the go routines to finish).

Additional changes:
- I have also introduced a new constant B to represent the size of a byte.
- Makefile command to build the tests and run the benchmarks.